### PR TITLE
fix:지식쇼핑/쇼핑하우가 특정호스팅에서 잘리는 현상. 루프단위로 버퍼 출력하도록 조정

### DIFF
--- a/shop/price/daum.php
+++ b/shop/price/daum.php
@@ -3,67 +3,66 @@ include_once('./_common.php');
 
 
 
-ob_start(); 
 
 header("Content-Type: text/html; charset=utf-8");
 
 /*
-	 구분 태그명	내용	설명	크기
-1	<<<begin>>>	    시작	상품시작 알림	필수
-2	<<<pid>>>	    상품ID	해당사 상품 ID	필수,varchar(50)
-3	<<<price>>>	    가격	상품 가격 	필수,number
-4	<<<pname>>>	    상품명	상품명	필수,varchar(500)
-5	<<<pgurl>>>	    상품링크	해당 상품으로 갈 상품URL	필수,varchar(255)
-6	<<<igurl>>>	    이미지링크	상품이미지 링크
-                    (상품이미지 중 제일 큰이미지링크)	필수,varchar(255)
-7	<<<cate1>>>     대분류ID	대분류 코드	필수,varchar(20)
-8	<<<cate2>>>     중분류ID	중분류 코드	varchar(20)
-9	<<<cate3>>>     소분류ID	소분류 코드	varchar(20)
-10	<<<cate4>>>     세분류ID	세분류 코드	varchar(20)
-11	<<<catename1>>>	대분류명		필수,varchar(50)
-12	<<<catename2>>>	중분류명		varchar(50)
-13	<<<catename3>>>	소분류명		varchar(50)
-14	<<<catename4>>>	세분류명		varchar(50)
-15	<<<model>>>	    모델명		varchar(255)
-16	<<<brand>>>	    브랜드명		varchar(255)
-17	<<<maker>>>	    제조사		varchar(255)
-18	<<<pdate>>>	    출시일	예) 20070101	varchar(8)
-19	<<<weight>>>	가중치값	숫자 ( 0  ~ )
+     구분 태그명 내용  설명  크기
+1   <<<begin>>>     시작  상품시작 알림 필수
+2   <<<pid>>>       상품ID    해당사 상품 ID   필수,varchar(50)
+3   <<<price>>>     가격  상품 가격   필수,number
+4   <<<pname>>>     상품명 상품명 필수,varchar(500)
+5   <<<pgurl>>>     상품링크    해당 상품으로 갈 상품URL 필수,varchar(255)
+6   <<<igurl>>>     이미지링크   상품이미지 링크
+                    (상품이미지 중 제일 큰이미지링크) 필수,varchar(255)
+7   <<<cate1>>>     대분류ID   대분류 코드  필수,varchar(20)
+8   <<<cate2>>>     중분류ID   중분류 코드  varchar(20)
+9   <<<cate3>>>     소분류ID   소분류 코드  varchar(20)
+10  <<<cate4>>>     세분류ID   세분류 코드  varchar(20)
+11  <<<catename1>>> 대분류명        필수,varchar(50)
+12  <<<catename2>>> 중분류명        varchar(50)
+13  <<<catename3>>> 소분류명        varchar(50)
+14  <<<catename4>>> 세분류명        varchar(50)
+15  <<<model>>>     모델명     varchar(255)
+16  <<<brand>>>     브랜드명        varchar(255)
+17  <<<maker>>>     제조사     varchar(255)
+18  <<<pdate>>>     출시일 예) 20070101 varchar(8)
+19  <<<weight>>>    가중치값    숫자 ( 0  ~ )
                     쇼핑몰대분류카테고리 기준으로
                     쇼핑몰내부에서 책정되는 상품에 대한
-                    인기점수	Numer(14)
-20	<<<sales>>>	    판매량	해당 상품이 팔린 누적판매량	number(14)
-21	<<<coupon>>>	쿠폰정보	퍼센트 쿠폰인 경우
+                    인기점수    Numer(14)
+20  <<<sales>>>     판매량 해당 상품이 팔린 누적판매량 number(14)
+21  <<<coupon>>>    쿠폰정보    퍼센트 쿠폰인 경우
                     ex) 5%할인쿠폰 -> 5%
                     일정가격할인 쿠폰인 경우
                     ex) 3000원할인쿠폰 -> 3000원
                     만 표기
-                    0%, 0원은 값을 제거	varchar(255)
+                    0%, 0원은 값을 제거   varchar(255)
 
-22	<<<pcard>>>     무이자/할부	카드이름개월수 형식으로 표시
+22  <<<pcard>>>     무이자/할부  카드이름개월수 형식으로 표시
                     ex) 삼성2~3/롯데3/현대6
-                    0개월 일 때에는 값을 제거	varchar(255)
-23	<<<point>>>	    적립금/포인트	텍스트정보
-                    0일 때에는 값을 제거	varchar(255)
-24	<<<deliv>>>	    배송비	무료일 때는 0
+                    0개월 일 때에는 값을 제거 varchar(255)
+23  <<<point>>>     적립금/포인트 텍스트정보
+                    0일 때에는 값을 제거    varchar(255)
+24  <<<deliv>>>     배송비 무료일 때는 0
                     유료일 때는 1
-                    조건부무료일 때는 2 로 표기	number
-25	<<<deliv2>>>	배송비 조건	유료(deliv필드 코드1번) or
+                    조건부무료일 때는 2 로 표기    number
+25  <<<deliv2>>>    배송비 조건  유료(deliv필드 코드1번) or
                     조건부무료(deliv필드 코드2번)
                     인 경우에 상세 조건 표기
-                    ex)3만원미만무료 or 2500원	varchar(20)
-26	<<<review>>>	상품평수	상품의 상품평개수가 몇 개인지 숫자만 표기	number
-27	<<<event>>>	    이벤트	해당 상품의 이벤트 내용을 표기
+                    ex)3만원미만무료 or 2500원 varchar(20)
+26  <<<review>>>    상품평수    상품의 상품평개수가 몇 개인지 숫자만 표기 number
+27  <<<event>>>     이벤트 해당 상품의 이벤트 내용을 표기
                     ex) 새봄맞이 행복이벤트! 새출발 아이템 50%SALE
-                    신규회원 5%+전상품 3%할인쿠폰	varchar(255)
-28	<<<eventurl>>>	이벤트url	event 페이지 URL	varchar(255)
-29	<<<sellername>>>	실판매자샵명	실제로 상품을 판매하고있는 판매자샵 이름 표기 (판매샵의 대표자명이 아니라 판매샵명)
-                        판매자샵명이 없는 경우에는 판매자아이디로 표기 (자체판매하는 경우에는 표기X)	varchar(20)
-30	<<<sellershop>>>	실판매자샵주소	판매자의 미니샵 주소 or 판매자샵주소
-                        (자체판매하는 경우에는 표기X)	varchar(50)
-31	<<<sellergrade>>>	실판매자등급	판매자등급을 5점 만점기준으로
-                        (자체판매하는 경우에는 표기X)	number
-32	<<<end>>>	    끝알림	끝알림 태그	필수
+                    신규회원 5%+전상품 3%할인쿠폰  varchar(255)
+28  <<<eventurl>>>  이벤트url  event 페이지 URL   varchar(255)
+29  <<<sellername>>>    실판매자샵명  실제로 상품을 판매하고있는 판매자샵 이름 표기 (판매샵의 대표자명이 아니라 판매샵명)
+                        판매자샵명이 없는 경우에는 판매자아이디로 표기 (자체판매하는 경우에는 표기X) varchar(20)
+30  <<<sellershop>>>    실판매자샵주소 판매자의 미니샵 주소 or 판매자샵주소
+                        (자체판매하는 경우에는 표기X)   varchar(50)
+31  <<<sellergrade>>>   실판매자등급  판매자등급을 5점 만점기준으로
+                        (자체판매하는 경우에는 표기X)   number
+32  <<<end>>>       끝알림 끝알림 태그  필수
 */
 
 $lt = "<<<";
@@ -71,35 +70,58 @@ $gt = ">>>";
 $shop_url = G5_SHOP_URL;
 $data_url = G5_DATA_URL;
 
-$sql =" select * from {$g5['g5_shop_item_table']} where it_use = '1' order by ca_id";
+$sql =" SELECT * FROM {$g5['g5_shop_item_table']} WHERE it_use = '1' and ca_id != '' order by ca_id";
 $result = sql_query($sql);
 
-for ($i=0; $row=sql_fetch_array($result); $i++)
+$category_arr = array();
+while ( $row=sql_fetch_array($result) )
 {
+    ob_start(); 
+
     $cate1 = $cate2 = $cate3 = $cate4 = "";
 
-    $row2 = sql_fetch(" select ca_id, ca_name from {$g5['g5_shop_category_table']} where ca_id = '".substr($row['ca_id'],0,2)."' ");
-    $cate1     = $row2['ca_id'];
+    $cate1 = substr($row['ca_id'],0,2) ;
+    if( empty($category_arr[$cate1]) ){
+        $row2 = sql_fetch(" SELECT ca_name FROM {$g5['g5_shop_category_table']} WHERE ca_id = '$cate1' ");
+        $category_arr[$cate1] = $row2;
+    }else{
+        $row2 = $category_arr[$cate1];
+    }
     $catename1 = $row2['ca_name'];
 
     $cate2 = $cate3 = $cate4 = "";
     $catename2 = $catename3 = $catename4 = "";
 
     if (strlen($row['ca_id']) >= 8) {
-        $row2 = sql_fetch(" select ca_id, ca_name from {$g5['g5_shop_category_table']} where ca_id = '".substr($row['ca_id'],0,8)."' ");
-        $cate4     = $row2['ca_id'];
+        $cate4 = substr($row['ca_id'],0,8) ;
+        if( empty($category_arr[$cate4]) ){
+            $row2 = sql_fetch(" SELECT ca_name FROM {$g5['g5_shop_category_table']} WHERE ca_id = '$cate4' ");
+            $category_arr[$cate4] = $row2;
+        }else{
+            $row2 = $category_arr[$cate4];
+        }
         $catename4 = $row2['ca_name'];
     }
 
     if (strlen($row['ca_id']) >= 6) {
-        $row2 = sql_fetch(" select ca_id, ca_name from {$g5['g5_shop_category_table']} where ca_id = '".substr($row['ca_id'],0,6)."' ");
-        $cate3     = $row2['ca_id'];
+        $cate3 = substr($row['ca_id'],0,6) ;
+        if( empty($category_arr[$cate3]) ){
+            $row2 = sql_fetch(" SELECT ca_name FROM {$g5['g5_shop_category_table']} WHERE ca_id = '$cate3' ");
+            $category_arr[$cate3] = $row2;
+        }else{
+            $row2 = $category_arr[$cate3];
+        }
         $catename3 = $row2['ca_name'];
     }
 
     if (strlen($row['ca_id']) >= 4) {
-        $row2 = sql_fetch(" select ca_id, ca_name from {$g5['g5_shop_category_table']} where ca_id = '".substr($row['ca_id'],0,4)."' ");
-        $cate2     = $row2['ca_id'];
+        $cate2 = substr($row['ca_id'],0,4) ;
+        if( empty($category_arr[$cate2]) ){
+            $row2 = sql_fetch(" SELECT ca_name FROM {$g5['g5_shop_category_table']} WHERE ca_id = '$cate2' ");
+            $category_arr[$cate2] = $row2;
+        }else{
+            $row2 = $category_arr[$cate2];
+        }
         $catename2 = $row2['ca_name'];
     }
 
@@ -142,13 +164,19 @@ for ($i=0; $row=sql_fetch_array($result); $i++)
 {$lt}end{$gt}
 
 HEREDOC;
-}
 
-
-
+// line 단위 출력.
 $content = ob_get_contents(); 
 ob_end_clean(); 
 
 $content = iconv('utf-8', 'euc-kr', $content); 
-echo $content; 
-?>
+echo $content;
+flush(); // 버퍼 출력.
+
+
+} // end while
+
+
+
+// end file
+

--- a/shop/price/naver.php
+++ b/shop/price/naver.php
@@ -1,7 +1,8 @@
 <?php
 include_once('./_common.php');
 
-ob_start();
+
+header("Content-Type: text/html; charset=euc-kr");
 
 /*
 네이버지식쇼핑상품EP (Engine Page) 제작및연동가이드 (제휴사제공용)
@@ -42,16 +43,24 @@ $gt = ">>>";
 $shop_url = G5_SHOP_URL;
 $data_url = G5_DATA_URL;
 
-$sql =" select * from {$g5['g5_shop_item_table']} where it_use = '1' order by ca_id";
+$sql =" SELECT * FROM {$g5['g5_shop_item_table']} WHERE it_use = '1' and ca_id != '' order by ca_id";
 $result = sql_query($sql);
 
-for ($i=0; $row=sql_fetch_array($result); $i++)
+$category_arr = array();
+while ( $row=sql_fetch_array($result) )
 {
+    ob_start();
+
     $cate1 = $cate2 = $cate3 = $cate4 = "";
     $caid1 = $caid2 = $caid3 = $caid4 = "";
 
     $caid1 = substr($row['ca_id'],0,2);
-    $row2 = sql_fetch(" select ca_name from {$g5['g5_shop_category_table']} where ca_id = '$caid1' ");
+    if( empty($category_arr[$caid1]) ){
+        $row2 = sql_fetch(" SELECT ca_name FROM {$g5['g5_shop_category_table']} WHERE ca_id = '$caid1' ");
+        $category_arr[$caid1] = $row2;
+    }else{
+        $row2 = $category_arr[$caid1];
+    }
     $cate1 = $row2['ca_name'];
 
     $caid2 = $caid3 = $caid4 = "";
@@ -59,19 +68,34 @@ for ($i=0; $row=sql_fetch_array($result); $i++)
 
     if (strlen($row['ca_id']) >= 8) {
         $caid4 = substr($row['ca_id'],0,8);
-        $row2 = sql_fetch(" select ca_name from {$g5['g5_shop_category_table']} where ca_id = '$caid4' ");
+        if( empty($category_arr[$caid4]) ){
+            $row2 = sql_fetch(" SELECT ca_name FROM {$g5['g5_shop_category_table']} WHERE ca_id = '$caid4' ");
+            $category_arr[$caid4] = $row2;
+        }else{
+            $row2 = $category_arr[$caid4];
+        }
         $cate4 = $row2['ca_name'];
     }
 
     if (strlen($row['ca_id']) >= 6) {
         $caid3 = substr($row['ca_id'],0,6);
-        $row2 = sql_fetch(" select ca_name from {$g5['g5_shop_category_table']} where ca_id = '$caid3' ");
+        if( empty($category_arr[$caid3]) ){
+            $row2 = sql_fetch(" SELECT ca_name FROM {$g5['g5_shop_category_table']} WHERE ca_id = '$caid3' ");
+            $category_arr[$caid3] = $row2;
+        }else{
+            $row2 = $category_arr[$caid3];
+        }
         $cate3 = $row2['ca_name'];
     }
 
     if (strlen($row['ca_id']) >= 4) {
         $caid2 = substr($row['ca_id'],0,4);
-        $row2 = sql_fetch(" select ca_name from {$g5['g5_shop_category_table']} where ca_id = '$caid2' ");
+        if( empty($category_arr[$caid2]) ){
+            $row2 = sql_fetch(" SELECT ca_name FROM {$g5['g5_shop_category_table']} WHERE ca_id = '$caid2' ");
+            $category_arr[$caid2] = $row2;
+        }else{
+            $row2 = $category_arr[$caid2];
+        }
         $cate2 = $row2['ca_name'];
     }
 
@@ -114,7 +138,6 @@ for ($i=0; $row=sql_fetch_array($result); $i++)
 {$lt}ftend{$gt}
 
 HEREDOC;
-}
 
 $content = ob_get_contents();
 ob_end_clean();
@@ -123,4 +146,9 @@ ob_end_clean();
 $content = iconv('utf-8', 'euc-kr', $content);
 
 echo $content;
-?>
+flush();
+
+} // end while
+
+
+// end file.


### PR DESCRIPTION
특정호스팅에서 모두 출력이 되지 않고, 잘리는 현상이 발견됨.
iconv 의 문제인지? 설정의 문제인지. 루프에서 상품단위로 출력을 하도록 조정.
카테고리 정보를 매번 쿼리로 처리하던것을 변수에 담아. 디비쿼리를 최소화함.
