### PR TITLE
이미지 파일 이름 중복 업로드시 다른 영역 파일로 같이 변경 되어 버리는 문제 수정

### DIFF
--- a/adm/shop_admin/itemformupdate.php
+++ b/adm/shop_admin/itemformupdate.php
@@ -106,7 +106,8 @@ if ($_FILES['it_img1']['name']) {
         @unlink($file_img1);
         delete_item_thumbnail(dirname($file_img1), basename($file_img1));
     }
-    $it_img1 = it_img_upload($_FILES['it_img1']['tmp_name'], $_FILES['it_img1']['name'], $it_img_dir.'/'.$it_id);
+
+    $it_img1 = it_img_upload($_FILES['it_img1']['tmp_name'], 'img1.'.pathinfo($_FILES['it_img1']['name'], PATHINFO_EXTENSION), $it_img_dir.'/'.$it_id);
 }
 if ($_FILES['it_img2']['name']) {
     if($w == 'u' && $it_img2) {
@@ -114,7 +115,7 @@ if ($_FILES['it_img2']['name']) {
         @unlink($file_img2);
         delete_item_thumbnail(dirname($file_img2), basename($file_img2));
     }
-    $it_img2 = it_img_upload($_FILES['it_img2']['tmp_name'], $_FILES['it_img2']['name'], $it_img_dir.'/'.$it_id);
+    $it_img2 = it_img_upload($_FILES['it_img2']['tmp_name'], 'img2.'.pathinfo($_FILES['it_img2']['name'], PATHINFO_EXTENSION), $it_img_dir.'/'.$it_id);
 }
 if ($_FILES['it_img3']['name']) {
     if($w == 'u' && $it_img3) {
@@ -122,7 +123,7 @@ if ($_FILES['it_img3']['name']) {
         @unlink($file_img3);
         delete_item_thumbnail(dirname($file_img3), basename($file_img3));
     }
-    $it_img3 = it_img_upload($_FILES['it_img3']['tmp_name'], $_FILES['it_img3']['name'], $it_img_dir.'/'.$it_id);
+    $it_img3 = it_img_upload($_FILES['it_img3']['tmp_name'], 'img3.'.pathinfo($_FILES['it_img3']['name'], PATHINFO_EXTENSION), $it_img_dir.'/'.$it_id);
 }
 if ($_FILES['it_img4']['name']) {
     if($w == 'u' && $it_img4) {
@@ -130,7 +131,7 @@ if ($_FILES['it_img4']['name']) {
         @unlink($file_img4);
         delete_item_thumbnail(dirname($file_img4), basename($file_img4));
     }
-    $it_img4 = it_img_upload($_FILES['it_img4']['tmp_name'], $_FILES['it_img4']['name'], $it_img_dir.'/'.$it_id);
+    $it_img4 = it_img_upload($_FILES['it_img4']['tmp_name'], 'img4.'.pathinfo($_FILES['it_img4']['name'], PATHINFO_EXTENSION), $it_img_dir.'/'.$it_id);
 }
 if ($_FILES['it_img5']['name']) {
     if($w == 'u' && $it_img5) {
@@ -138,7 +139,7 @@ if ($_FILES['it_img5']['name']) {
         @unlink($file_img5);
         delete_item_thumbnail(dirname($file_img5), basename($file_img5));
     }
-    $it_img5 = it_img_upload($_FILES['it_img5']['tmp_name'], $_FILES['it_img5']['name'], $it_img_dir.'/'.$it_id);
+    $it_img5 = it_img_upload($_FILES['it_img5']['tmp_name'], 'img5.'.pathinfo($_FILES['it_img5']['name'], PATHINFO_EXTENSION), $it_img_dir.'/'.$it_id);
 }
 if ($_FILES['it_img6']['name']) {
     if($w == 'u' && $it_img6) {
@@ -146,7 +147,7 @@ if ($_FILES['it_img6']['name']) {
         @unlink($file_img6);
         delete_item_thumbnail(dirname($file_img6), basename($file_img6));
     }
-    $it_img6 = it_img_upload($_FILES['it_img6']['tmp_name'], $_FILES['it_img6']['name'], $it_img_dir.'/'.$it_id);
+    $it_img6 = it_img_upload($_FILES['it_img6']['tmp_name'], 'img6.'.pathinfo($_FILES['it_img6']['name'], PATHINFO_EXTENSION), $it_img_dir.'/'.$it_id);
 }
 if ($_FILES['it_img7']['name']) {
     if($w == 'u' && $it_img7) {
@@ -154,7 +155,7 @@ if ($_FILES['it_img7']['name']) {
         @unlink($file_img7);
         delete_item_thumbnail(dirname($file_img7), basename($file_img7));
     }
-    $it_img7 = it_img_upload($_FILES['it_img7']['tmp_name'], $_FILES['it_img7']['name'], $it_img_dir.'/'.$it_id);
+    $it_img7 = it_img_upload($_FILES['it_img7']['tmp_name'], 'img7.'.pathinfo($_FILES['it_img7']['name'], PATHINFO_EXTENSION), $it_img_dir.'/'.$it_id);
 }
 if ($_FILES['it_img8']['name']) {
     if($w == 'u' && $it_img8) {
@@ -162,7 +163,7 @@ if ($_FILES['it_img8']['name']) {
         @unlink($file_img8);
         delete_item_thumbnail(dirname($file_img8), basename($file_img8));
     }
-    $it_img8 = it_img_upload($_FILES['it_img8']['tmp_name'], $_FILES['it_img8']['name'], $it_img_dir.'/'.$it_id);
+    $it_img8 = it_img_upload($_FILES['it_img8']['tmp_name'], 'img8.'.pathinfo($_FILES['it_img8']['name'], PATHINFO_EXTENSION), $it_img_dir.'/'.$it_id);
 }
 if ($_FILES['it_img9']['name']) {
     if($w == 'u' && $it_img9) {
@@ -170,7 +171,7 @@ if ($_FILES['it_img9']['name']) {
         @unlink($file_img9);
         delete_item_thumbnail(dirname($file_img9), basename($file_img9));
     }
-    $it_img9 = it_img_upload($_FILES['it_img9']['tmp_name'], $_FILES['it_img9']['name'], $it_img_dir.'/'.$it_id);
+    $it_img9 = it_img_upload($_FILES['it_img9']['tmp_name'], 'img9.'.pathinfo($_FILES['it_img9']['name'], PATHINFO_EXTENSION), $it_img_dir.'/'.$it_id);
 }
 if ($_FILES['it_img10']['name']) {
     if($w == 'u' && $it_img10) {
@@ -178,7 +179,7 @@ if ($_FILES['it_img10']['name']) {
         @unlink($file_img10);
         delete_item_thumbnail(dirname($file_img10), basename($file_img10));
     }
-    $it_img10 = it_img_upload($_FILES['it_img10']['tmp_name'], $_FILES['it_img10']['name'], $it_img_dir.'/'.$it_id);
+    $it_img10 = it_img_upload($_FILES['it_img10']['tmp_name'], 'img10.'.pathinfo($_FILES['it_img10']['name'], PATHINFO_EXTENSION), $it_img_dir.'/'.$it_id);
 }
 
 if ($w == "" || $w == "u")
@@ -263,6 +264,8 @@ $it_name = strip_tags(trim($_POST['it_name']));
 if ($it_name == "")
     alert("상품명을 입력해 주십시오.");
 
+$it_type = strip_tags(trim($_POST['it_type']));
+
 $sql_common = " ca_id               = '$ca_id',
                 ca_id2              = '$ca_id2',
                 ca_id3              = '$ca_id3',
@@ -343,7 +346,8 @@ $sql_common = " ca_id               = '$ca_id',
                 it_7                = '$it_7',
                 it_8                = '$it_8',
                 it_9                = '$it_9',
-                it_10               = '$it_10'
+                it_10               = '$it_10',
+                it_type             = '$it_type'
                 ";
 
 if ($w == "")


### PR DESCRIPTION
문제 발생 단계
1. 이미지 1에 "이미지1.jpg" 파일을 업로드 저장
2. 이미지 2에 새로운 이미지 파일이지만 파일명이 같은 "이미지1.jpg" 파일을 업로드 저장
3. 이미지 1 파일이 같이 변경됨
4. 삭제시 이미지 1,2가 같이 삭제됨
