### PR TITLE
커뮤니티 사용여부 '정의되지 않은 상수 사용' 경고 해결

### DIFF
--- a/_common.php
+++ b/_common.php
@@ -2,7 +2,7 @@
 include_once('./common.php');
 
 // 커뮤니티 사용여부
-if(G5_COMMUNITY_USE === false) {
+if(defined('G5_COMMUNITY_USE') && G5_COMMUNITY_USE === false) {
     if (!defined('G5_USE_SHOP') || !G5_USE_SHOP)
         die('<p>쇼핑몰 설치 후 이용해 주십시오.</p>');
 


### PR DESCRIPTION
PHP 7.2.x
테마 제작자가 theme.config.php 파일에 커뮤니티 사용여부를 포함하지 않았을 경우,
테마적용시 상단에 뜨는 '정의되지 않은 상수 사용' 경고가 뜨는 것을 해결.